### PR TITLE
ci: add changelog and PR changelog check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,31 @@
+# Runs changelog related jobs.
+# CI job heavily inspired by: https://github.com/tarides/changelog-check-action
+
+name: changelog
+
+# Limits workflow concurrency to only the latest commit in the PR.
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Check for changes in changelog
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
+        run: ./scripts/check-changelog.sh
+        shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+## 0.4.2 (TBD)
+
+- [BREAKING] Removed `p3-miden-goldilocks` crate, now uses upstream `p3-goldilocks` (#3).
+- Updated `Pcs` trait implementation for Plonky3 v0.4.2 compatibility (#3).
+- Updated Plonky3 dependencies to v0.4.2 (#3).
+
+## 0.4.0 (2025-12-23)
+
+- Initial release on crates.io containing Miden-specific Plonky3 crates.
+- [BREAKING] Consolidated crates and removed duplicate symbolic modules to use base Plonky3 (#1).
+- Added workspace release automation with dry-run and publish workflows.
+- Migrated Plonky3 dependencies from git to crates.io v0.4.1 (#1).
+- Added README documenting the five Miden-specific Plonky3 crates.
+- Added dual MIT/Apache-2.0 license.
+- Added CI workflows and Makefile for build automation.
+- Fixed debug constraint checking to be gated behind `cfg(debug_assertions)`.
+
+### Crates included
+
+- `p3-miden-air`: Miden-specific AIR abstractions.
+- `p3-miden-fri`: Miden FRI implementation with hiding commitments.
+- `p3-miden-prover`: Miden prover with constraint checking.
+- `p3-miden-uni-stark`: Miden uni-STARK implementation.

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -uo pipefail
+
+CHANGELOG_FILE="${1:-CHANGELOG.md}"
+
+if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
+    # 'no changelog' set, so finish successfully
+    echo "\"no changelog\" label has been set"
+    exit 0
+else
+    # a changelog check is required
+    # fail if the diff is empty
+    if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
+        >&2 echo "Changes should come with an entry in the \"CHANGELOG.md\" file. This behavior
+can be overridden by using the \"no changelog\" label, which is used for changes
+that are trivial / explicitly stated not to require a changelog entry."
+        exit 1
+    fi
+
+    echo "The \"CHANGELOG.md\" file has been updated."
+fi


### PR DESCRIPTION
Add CHANGELOG.md documenting v0.4.0 and upcoming v0.4.2 releases.
Add CI workflow that requires CHANGELOG updates on PRs (skippable with "no changelog" label).