### PR TITLE
ci: Advance workspace to 0.5.1 and harden release dry-run validation

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -37,15 +37,19 @@ runs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
+    # Keep the release dry-run cache tightly scoped to the exact manifest set.
+    #
+    # This job is meant to answer "would this workspace publish cleanly now?".
+    # Broad restore keys or a key derived only from Cargo.lock can hide or
+    # retain resolution state across release lines, which makes failures harder
+    # to attribute when internal crates change without a version bump.
     - name: Cache cargo registry and git index
       uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+        key: ${{ runner.os }}-cargo-release-${{ hashFiles('Cargo.toml', '**/Cargo.toml', 'rust-toolchain', 'rust-toolchain.toml') }}
 
     - name: Cleanup large tools for build space
       uses: ./.github/actions/cleanup-runner
@@ -57,6 +61,14 @@ runs:
         echo "Cleaning target/package directory to ensure fresh state"
         rm -rf target/package
 
+    # Note: `cargo publish --workspace --dry-run` verifies each crate as it
+    # would be published. If a releasable internal crate changes incompatibly
+    # while keeping the same version, downstream crates can resolve against the
+    # already-published registry copy instead of the just-updated source and the
+    # dry-run should fail until the version line is advanced.
+    #
+    # That is desirable: it catches release skew before a real publish does.
+    #
     # Dry-run vs real publish
     - name: Dry-run workspace publish
       if: ${{ inputs.mode == 'dry-run' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bumped the workspace release line to `0.5.1` after the post-`0.5.0` LMCS changes. Without a version bump, `cargo publish --workspace --dry-run` can verify downstream crates against the already-published `0.5.0` registry copy instead of the updated local LMCS package, producing a mixed and invalid release graph.
+
 - Dropped BabyBear support; simplified tests, benchmarks, and dev-utils to Goldilocks-only ([#52](https://github.com/0xMiden/p3-miden/pull/52)).
 - Added crate-local `testing` modules to `p3-miden-lmcs` and `p3-miden-lifted-fri` behind a `testing` feature flag ([#52](https://github.com/0xMiden/p3-miden/pull/52)).
 - Moved `p3-miden-lifted-examples` from `[[example]]` to `[[bin]]` entries ([#52](https://github.com/0xMiden/p3-miden/pull/52)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased
 
-- Bumped the workspace release line to `0.5.1` after the post-`0.5.0` LMCS changes. Without a version bump, `cargo publish --workspace --dry-run` can verify downstream crates against the already-published `0.5.0` registry copy instead of the updated local LMCS package, producing a mixed and invalid release graph.
-
 - Dropped BabyBear support; simplified tests, benchmarks, and dev-utils to Goldilocks-only ([#52](https://github.com/0xMiden/p3-miden/pull/52)).
 - Added crate-local `testing` modules to `p3-miden-lmcs` and `p3-miden-lifted-fri` behind a `testing` feature flag ([#52](https://github.com/0xMiden/p3-miden/pull/52)).
 - Moved `p3-miden-lifted-examples` from `[[example]]` to `[[bin]]` entries ([#52](https://github.com/0xMiden/p3-miden/pull/52)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,25 +33,25 @@ p3-miden-stateful-hasher = { path = "p3-miden-stateful-hasher", version = "0.5.1
 p3-miden-transcript = { path = "p3-miden-transcript", version = "0.5.1" }
 
 # Plonky3 (trait crates)
-p3-air = { version = "0.5.0", default-features = false }
-p3-challenger = { version = "0.5.0", default-features = false }
-p3-commit = { version = "0.5.0", default-features = false }
-p3-dft = { version = "0.5.0", default-features = false }
-p3-field = { version = "0.5.0", default-features = false }
-p3-matrix = { version = "0.5.0", default-features = false }
-p3-maybe-rayon = { version = "0.5.0", default-features = false }
-p3-symmetric = { version = "0.5.0", default-features = false }
-p3-util = { version = "0.5.0", default-features = false }
+p3-air = { version = "0.5", default-features = false }
+p3-challenger = { version = "0.5", default-features = false }
+p3-commit = { version = "0.5", default-features = false }
+p3-dft = { version = "0.5", default-features = false }
+p3-field = { version = "0.5", default-features = false }
+p3-matrix = { version = "0.5", default-features = false }
+p3-maybe-rayon = { version = "0.5", default-features = false }
+p3-symmetric = { version = "0.5", default-features = false }
+p3-util = { version = "0.5", default-features = false }
 
 # Plonky3 (concrete implementations — dev/test/bench only in core crates)
-p3-blake3 = { version = "0.5.0", default-features = false }
-p3-bn254 = { version = "0.5.0", default-features = false }
-p3-fri = { version = "0.5.0", default-features = false }
-p3-goldilocks = { version = "0.5.0", default-features = false }
-p3-interpolation = { version = "0.5.0", default-features = false }
-p3-keccak = { version = "0.5.0", default-features = false }
-p3-merkle-tree = { version = "0.5.0", default-features = false }
-p3-mersenne-31 = { version = "0.5.0", default-features = false }
+p3-blake3 = { version = "0.5", default-features = false }
+p3-bn254 = { version = "0.5", default-features = false }
+p3-fri = { version = "0.5", default-features = false }
+p3-goldilocks = { version = "0.5", default-features = false }
+p3-interpolation = { version = "0.5", default-features = false }
+p3-keccak = { version = "0.5", default-features = false }
+p3-merkle-tree = { version = "0.5", default-features = false }
+p3-mersenne-31 = { version = "0.5", default-features = false }
 
 # Third-party
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ homepage = "https://github.com/0xMiden/p3-miden"
 [workspace.dependencies]
 
 # Internal
-p3-miden-dev-utils = { path = "p3-miden-dev-utils", version = "0.5.1" }
-p3-miden-lifted-air = { path = "p3-miden-lifted-air", version = "0.5.1" }
-p3-miden-lifted-examples = { path = "p3-miden-lifted-examples", version = "0.5.1" }
-p3-miden-lifted-fri = { path = "p3-miden-lifted-fri", version = "0.5.1" }
-p3-miden-lifted-stark = { path = "p3-miden-lifted-stark", version = "0.5.1" }
-p3-miden-lmcs = { path = "p3-miden-lmcs", version = "0.5.1" }
-p3-miden-stateful-hasher = { path = "p3-miden-stateful-hasher", version = "0.5.1" }
-p3-miden-transcript = { path = "p3-miden-transcript", version = "0.5.1" }
+p3-miden-dev-utils = { path = "p3-miden-dev-utils", version = "0.5" }
+p3-miden-lifted-air = { path = "p3-miden-lifted-air", version = "0.5" }
+p3-miden-lifted-examples = { path = "p3-miden-lifted-examples", version = "0.5" }
+p3-miden-lifted-fri = { path = "p3-miden-lifted-fri", version = "0.5" }
+p3-miden-lifted-stark = { path = "p3-miden-lifted-stark", version = "0.5" }
+p3-miden-lmcs = { path = "p3-miden-lmcs", version = "0.5" }
+p3-miden-stateful-hasher = { path = "p3-miden-stateful-hasher", version = "0.5" }
+p3-miden-transcript = { path = "p3-miden-transcript", version = "0.5" }
 
 # Plonky3 (trait crates)
 p3-air = { version = "0.5", default-features = false }
@@ -44,14 +44,20 @@ p3-symmetric = { version = "0.5", default-features = false }
 p3-util = { version = "0.5", default-features = false }
 
 # Plonky3 (concrete implementations — dev/test/bench only in core crates)
+p3-batch-stark = { version = "0.5", default-features = false }
 p3-blake3 = { version = "0.5", default-features = false }
+p3-blake3-air = { version = "0.5", default-features = false }
 p3-bn254 = { version = "0.5", default-features = false }
 p3-fri = { version = "0.5", default-features = false }
 p3-goldilocks = { version = "0.5", default-features = false }
 p3-interpolation = { version = "0.5", default-features = false }
 p3-keccak = { version = "0.5", default-features = false }
+p3-keccak-air = { version = "0.5", default-features = false }
+p3-lookup = { version = "0.5", default-features = false }
 p3-merkle-tree = { version = "0.5", default-features = false }
 p3-mersenne-31 = { version = "0.5", default-features = false }
+p3-poseidon2-air = { version = "0.5", default-features = false }
+p3-uni-stark = { version = "0.5", default-features = false }
 
 # Third-party
 criterion = { version = "0.8", features = ["html_reports"] }
@@ -69,3 +75,4 @@ tracing-subscriber = { version = "0.3.17", features = [
   "fmt",
   "env-filter",
 ] }
+tracing-forest = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.85"
@@ -23,14 +23,14 @@ homepage = "https://github.com/0xMiden/p3-miden"
 [workspace.dependencies]
 
 # Internal
-p3-miden-dev-utils = { path = "p3-miden-dev-utils", version = "0.5.0" }
-p3-miden-lifted-air = { path = "p3-miden-lifted-air", version = "0.5.0" }
-p3-miden-lifted-examples = { path = "p3-miden-lifted-examples", version = "0.5.0" }
-p3-miden-lifted-fri = { path = "p3-miden-lifted-fri", version = "0.5.0" }
-p3-miden-lifted-stark = { path = "p3-miden-lifted-stark", version = "0.5.0" }
-p3-miden-lmcs = { path = "p3-miden-lmcs", version = "0.5.0" }
-p3-miden-stateful-hasher = { path = "p3-miden-stateful-hasher", version = "0.5.0" }
-p3-miden-transcript = { path = "p3-miden-transcript", version = "0.5.0" }
+p3-miden-dev-utils = { path = "p3-miden-dev-utils", version = "0.5.1" }
+p3-miden-lifted-air = { path = "p3-miden-lifted-air", version = "0.5.1" }
+p3-miden-lifted-examples = { path = "p3-miden-lifted-examples", version = "0.5.1" }
+p3-miden-lifted-fri = { path = "p3-miden-lifted-fri", version = "0.5.1" }
+p3-miden-lifted-stark = { path = "p3-miden-lifted-stark", version = "0.5.1" }
+p3-miden-lmcs = { path = "p3-miden-lmcs", version = "0.5.1" }
+p3-miden-stateful-hasher = { path = "p3-miden-stateful-hasher", version = "0.5.1" }
+p3-miden-transcript = { path = "p3-miden-transcript", version = "0.5.1" }
 
 # Plonky3 (trait crates)
 p3-air = { version = "0.5.0", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,13 @@ test-all: test test-parallel ## Run all test variants
 check: ## Check all targets and features for errors without code generation
 	cargo check --all-targets --all-features
 
+.PHONY: check-features
+check-features: ## Check the supported non-default feature combinations
+	cargo check --workspace --all-targets --no-default-features
+	cargo check --workspace --all-targets --features parallel
+	cargo check -p p3-miden-lmcs --all-targets --features testing
+	cargo check -p p3-miden-lifted-fri --all-targets --features testing
+
 # --- building ------------------------------------------------------------------------------------
 
 .PHONY: build

--- a/p3-miden-lifted-examples/Cargo.toml
+++ b/p3-miden-lifted-examples/Cargo.toml
@@ -15,17 +15,17 @@ p3-miden-lifted-air.workspace = true
 
 # Plonky3
 p3-air.workspace = true
-p3-blake3-air = { version = "0.5.0", default-features = false }
+p3-blake3-air = { workspace = true }
 p3-field.workspace = true
-p3-keccak-air = { version = "0.5.0", default-features = false }
+p3-keccak-air = { workspace = true }
 p3-matrix.workspace = true
-p3-poseidon2-air = { version = "0.5.0", default-features = false }
+p3-poseidon2-air = { workspace = true }
 
 # Third-party
 rand.workspace = true
 serde.workspace = true
 tracing.workspace = true
-tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
+tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 tracing-subscriber.workspace = true
 
 # Internal
@@ -33,16 +33,16 @@ p3-miden-lmcs = { workspace = true, features = ["testing"] }
 p3-miden-lifted-stark.workspace = true
 
 # Plonky3
-p3-batch-stark = { version = "0.5.0", default-features = false }
+p3-batch-stark = { workspace = true }
 p3-challenger.workspace = true
 p3-commit.workspace = true
 p3-dft.workspace = true
 p3-fri.workspace = true
 p3-goldilocks.workspace = true
-p3-lookup = { version = "0.5.0", default-features = false }
+p3-lookup = { workspace = true }
 p3-merkle-tree.workspace = true
 p3-symmetric.workspace = true
-p3-uni-stark = { version = "0.5.0", default-features = false }
+p3-uni-stark = { workspace = true }
 p3-util.workspace = true
 
 [features]

--- a/p3-miden-lifted-fri/Cargo.toml
+++ b/p3-miden-lifted-fri/Cargo.toml
@@ -15,7 +15,7 @@ p3-miden-transcript.workspace = true
 
 # Plonky3
 p3-challenger.workspace = true
-p3-commit.workspace = true
+p3-commit = { workspace = true, optional = true }
 p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
@@ -47,7 +47,7 @@ tracing-subscriber.workspace = true
 
 [features]
 parallel = ["p3-maybe-rayon/parallel"]
-testing = ["p3-miden-lmcs/testing"]
+testing = ["p3-miden-lmcs/testing", "p3-commit"]
 
 [[bench]]
 name = "fri_fold"


### PR DESCRIPTION
This fixes the [failing release-dry-run job](https://github.com/0xMiden/p3-miden/actions/workflows/release-dry-run.yml) by moving the workspace off the already-published 0.5.0 line after the LMCS refactor. Without that bump, `cargo publish --workspace --dry-run` could verify downstream crates against the published `p3-miden-lmcs` 0.5.0 crate instead of the updated local package, producing an invalid mixed release graph.

It also hardens the release workflow by tightening the cargo cache key to the current manifest set and documenting the version-skew failure mode directly in the workflow. Finally, it adds a root `make check-features` target so the repo has an explicit feature-validation entry point alongside the existing check, test, and lint targets.